### PR TITLE
Fix callback filtering for model and language selection

### DIFF
--- a/handlers/language.py
+++ b/handlers/language.py
@@ -118,5 +118,13 @@ async def choose_target_language(callback: types.CallbackQuery, state: FSMContex
 
 def register_handlers_language(dp):
     """РЕЄСТРАЦІЯ HANDLER'ІВ МОВ"""
-    dp.register_callback_query_handler(choose_source_language)  # БЕЗ ОБМЕЖЕНЬ
-    dp.register_callback_query_handler(choose_target_language)  # БЕЗ ОБМЕЖЕНЬ
+    dp.register_callback_query_handler(
+        choose_source_language,
+        lambda c: c.data and c.data.startswith("lang_"),
+        state=TranslationStates.waiting_for_source_language,
+    )
+    dp.register_callback_query_handler(
+        choose_target_language,
+        lambda c: c.data and c.data.startswith("lang_"),
+        state=TranslationStates.waiting_for_target_language,
+    )

--- a/handlers/payment.py
+++ b/handlers/payment.py
@@ -67,6 +67,18 @@ async def upload_another(callback: types.CallbackQuery, state: FSMContext):
 
 def register_handlers_payment(dp):
     """РЕЄСТРАЦІЯ HANDLER'ІВ ОПЛАТИ"""
-    dp.register_callback_query_handler(process_payment, lambda c: c.data and c.data == "process_payment")
-    dp.register_callback_query_handler(payment_done, lambda c: c.data and c.data == "payment_done")
-    dp.register_callback_query_handler(upload_another, lambda c: c.data and c.data == "upload_another")
+    dp.register_callback_query_handler(
+        process_payment,
+        lambda c: c.data == "process_payment",
+        state=TranslationStates.waiting_for_payment_confirmation,
+    )
+    dp.register_callback_query_handler(
+        payment_done,
+        lambda c: c.data == "payment_done",
+        state=TranslationStates.waiting_for_payment_confirmation,
+    )
+    dp.register_callback_query_handler(
+        upload_another,
+        lambda c: c.data == "upload_another",
+        state=TranslationStates.waiting_for_payment_confirmation,
+    )

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -153,8 +153,12 @@ def register_handlers_start(dp):
     dp.register_message_handler(cmd_start, commands=["start"], state="*")
     logger.info("✅ Зареєстровано cmd_start")
     
-    # Вибір моделі - БЕЗ ФІЛЬТРІВ (КЛЮЧОВЕ ВИПРАВЛЕННЯ)
-    dp.register_callback_query_handler(choose_model)
+    # Вибір моделі
+    dp.register_callback_query_handler(
+        choose_model,
+        lambda c: c.data and c.data.startswith("model_"),
+        state=TranslationStates.choosing_model,
+    )
     logger.info("✅ Зареєстровано choose_model")
     
     # Продовження


### PR DESCRIPTION
## Summary
- fix callback handler registration to ensure correct filters and states

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688564f83da48330b4deb326266d9141