### PR TITLE
Fix callback filtering for model and language selection

### DIFF
--- a/handlers/file.py
+++ b/handlers/file.py
@@ -2,6 +2,8 @@ from aiogram import types
 from aiogram.dispatcher import FSMContext
 from states import TranslationStates
 import logging
+from utils.file_utils import count_chars_in_file
+from utils.payment_utils import calculate_price
 import os
 
 logger = logging.getLogger(__name__)
@@ -53,13 +55,15 @@ async def handle_file(message: types.Message, state: FSMContext):
         await message.answer(f"🔤 Переклад: {source_name} → {target_name}")
         await message.answer(f"⚙️ Модель: {model_name}")
         
-        # Імітація обробки
+        # Аналіз файлу
         await message.answer("📊 Аналізую файл...")
-        await message.answer("🔢 Підраховую символи...")
-        
+        char_count = count_chars_in_file(file_path)
+        price = calculate_price(char_count, model)
+        await state.update_data(char_count=char_count, price=price)
+
         # Відображаємо статистику
         await message.answer("💳 <b>Розрахунок вартості:</b>", parse_mode="HTML")
-        await message.answer("• Символів: 514\n• Вартість: 0.65 €")
+        await message.answer(f"• Символів: {char_count}\n• Вартість: {price} €")
         
         # Кнопки оплати
         keyboard = types.InlineKeyboardMarkup()

--- a/handlers/language.py
+++ b/handlers/language.py
@@ -2,24 +2,39 @@ from aiogram import types
 from aiogram.dispatcher import FSMContext
 from states import TranslationStates
 import logging
+from utils.translate_utils import fetch_deepl_languages, fetch_otranslator_languages
 
 logger = logging.getLogger(__name__)
 
-# Helper функція для назв мов
-LANGUAGE_NAMES = {
-    "UK": "Українська",
-    "EN": "English",
-    "DE": "Deutsch",
-    "FR": "Français",
-    "ES": "Español",
-    "PL": "Polski",
-    "RU": "Русский",
-    "ZH": "中文",
-    "JA": "日本語"
-}
+# Languages will be fetched from APIs
+LANGUAGE_NAMES = {}
+LANGUAGE_NAMES.update(fetch_deepl_languages())
+LANGUAGE_NAMES.update(fetch_otranslator_languages())
+
+# Fallback minimal set if APIs fail
+if not LANGUAGE_NAMES:
+    LANGUAGE_NAMES = {
+        "UK": "Українська",
+        "EN": "English",
+        "DE": "Deutsch",
+        "FR": "Français",
+        "ES": "Español",
+        "PL": "Polski",
+        "RU": "Русский",
+        "ZH": "中文",
+        "JA": "日本語",
+    }
 
 def get_language_name(code):
     return LANGUAGE_NAMES.get(code, code)
+
+
+def build_language_keyboard() -> types.InlineKeyboardMarkup:
+    """Створює клавіатуру з усіма доступними мовами"""
+    keyboard = types.InlineKeyboardMarkup(row_width=3)
+    for code, name in LANGUAGE_NAMES.items():
+        keyboard.insert(types.InlineKeyboardButton(name, callback_data=f"lang_{code}"))
+    return keyboard
 
 async def choose_source_language(callback: types.CallbackQuery, state: FSMContext):
     """ВИБІР МОВИ ОРИГІНАЛУ"""
@@ -49,23 +64,7 @@ async def choose_source_language(callback: types.CallbackQuery, state: FSMContex
         await callback.message.answer("<b>Крок 3/5:</b> Оберіть мову перекладу:", parse_mode="HTML")
         
         # Кнопки мов
-        keyboard = types.InlineKeyboardMarkup(row_width=3)
-        keyboard.add(
-            types.InlineKeyboardButton("🇺🇦 UKR", callback_data="lang_UK"),
-            types.InlineKeyboardButton("🇬🇧 ENG", callback_data="lang_EN"),
-            types.InlineKeyboardButton("🇩🇪 GER", callback_data="lang_DE")
-        )
-        keyboard.add(
-            types.InlineKeyboardButton("🇫🇷 FRA", callback_data="lang_FR"),
-            types.InlineKeyboardButton("🇪🇸 SPA", callback_data="lang_ES"),
-            types.InlineKeyboardButton("🇵🇱 POL", callback_data="lang_PL")
-        )
-        keyboard.add(
-            types.InlineKeyboardButton("🇷🇺 RUS", callback_data="lang_RU"),
-            types.InlineKeyboardButton("🇨🇳 CHN", callback_data="lang_ZH"),
-            types.InlineKeyboardButton("🇯🇵 JPN", callback_data="lang_JA")
-        )
-        
+        keyboard = build_language_keyboard()
         await callback.message.answer("Виберіть мову:", reply_markup=keyboard)
         
         logger.info(f"✅ МОВА ОРИГІНАЛУ {language_code} вибрана для користувача {callback.from_user.id}")
@@ -118,5 +117,13 @@ async def choose_target_language(callback: types.CallbackQuery, state: FSMContex
 
 def register_handlers_language(dp):
     """РЕЄСТРАЦІЯ HANDLER'ІВ МОВ"""
-    dp.register_callback_query_handler(choose_source_language)  # БЕЗ ОБМЕЖЕНЬ
-    dp.register_callback_query_handler(choose_target_language)  # БЕЗ ОБМЕЖЕНЬ
+    dp.register_callback_query_handler(
+        choose_source_language,
+        lambda c: c.data and c.data.startswith("lang_"),
+        state=TranslationStates.waiting_for_source_language,
+    )
+    dp.register_callback_query_handler(
+        choose_target_language,
+        lambda c: c.data and c.data.startswith("lang_"),
+        state=TranslationStates.waiting_for_target_language,
+    )

--- a/handlers/payment.py
+++ b/handlers/payment.py
@@ -2,6 +2,7 @@ from aiogram import types
 from aiogram.dispatcher import FSMContext
 from states import TranslationStates
 import logging
+from utils.payment_utils import create_payment_session, verify_payment
 
 logger = logging.getLogger(__name__)
 
@@ -11,19 +12,41 @@ async def process_payment(callback: types.CallbackQuery, state: FSMContext):
         logger.info(f"💳 ОБРОБКА ОПЛАТИ для користувача {callback.from_user.id}")
         await callback.answer()
         
-        # Переходимо до стану оплати
-        await TranslationStates.waiting_for_payment_confirmation.set()
-        
-        # Заглушка для оплати
-        await callback.message.answer("💳 <b>Крок 5/5:</b> Оплата", parse_mode="HTML")
-        await callback.message.answer("⚠️ Система оплати в розробці. Натисніть кнопку нижче для продовження.")
-        
-        # Кнопка продовження без оплати (для тестування)
+        # Дані для оплати
+        user_data = await state.get_data()
+        price = user_data.get("price", 0.0)
+        char_count = user_data.get("char_count", 0)
+        model = user_data.get("model", "basic")
+
+        session_url, session_id = create_payment_session(
+            price, callback.from_user.id, char_count, model
+        ) or (None, None)
+
+        if not session_url:
+            await callback.message.answer("⚠️ Не вдалося створити сесію оплати")
+            return
+
+        await state.update_data(payment_session=session_id)
+
+        await callback.message.answer(
+            "💳 <b>Крок 5/5:</b> Оплата",
+            parse_mode="HTML",
+        )
+
         keyboard = types.InlineKeyboardMarkup()
-        keyboard.add(types.InlineKeyboardButton("⏭ Продовжити без оплати", callback_data="payment_done"))
-        keyboard.add(types.InlineKeyboardButton("🔄 Інший файл", callback_data="upload_another"))
-        
-        await callback.message.answer("Виберіть дію:", reply_markup=keyboard)
+        keyboard.add(
+            types.InlineKeyboardButton(
+                "💳 Перейти до оплати", url=session_url
+            )
+        )
+        keyboard.add(
+            types.InlineKeyboardButton("✅ Я оплатив", callback_data="payment_done")
+        )
+        keyboard.add(
+            types.InlineKeyboardButton("🔄 Інший файл", callback_data="upload_another")
+        )
+
+        await callback.message.answer("Натисніть кнопку, щоб оплатити", reply_markup=keyboard)
         
         logger.info(f"✅ ОПЛАТА ініційована для користувача {callback.from_user.id}")
         
@@ -34,16 +57,28 @@ async def process_payment(callback: types.CallbackQuery, state: FSMContext):
 async def payment_done(callback: types.CallbackQuery, state: FSMContext):
     """ОПЛАТА ЗДІЙСНЕНА"""
     try:
-        logger.info(f"✅ ОПЛАТА ПІДТВЕРДЖЕНА для користувача {callback.from_user.id}")
         await callback.answer()
-        
-        # Переходимо до перекладу
+
+        data = await state.get_data()
+        session_id = data.get("payment_session")
+
+        if not session_id:
+            await callback.message.answer("⚠️ Сесію оплати не знайдено")
+            return
+
+        result = verify_payment(session_id)
+        if not result.get("paid"):
+            await callback.message.answer("⚠️ Оплата ще не підтверджена")
+            return
+
         await TranslationStates.translating.set()
-        
+
         await callback.message.answer("✅ Оплата підтверджена!")
         await callback.message.answer("🔄 Починаємо переклад файлу...")
-        
-        logger.info(f"✅ ОПЛАТА підтверджена для користувача {callback.from_user.id}")
+
+        logger.info(
+            f"✅ ОПЛАТА підтверджена для користувача {callback.from_user.id}"
+        )
         
     except Exception as e:
         logger.error(f"❌ ПОМИЛКА в payment_done для користувача {callback.from_user.id}: {str(e)}")
@@ -67,6 +102,18 @@ async def upload_another(callback: types.CallbackQuery, state: FSMContext):
 
 def register_handlers_payment(dp):
     """РЕЄСТРАЦІЯ HANDLER'ІВ ОПЛАТИ"""
-    dp.register_callback_query_handler(process_payment, lambda c: c.data and c.data == "process_payment")
-    dp.register_callback_query_handler(payment_done, lambda c: c.data and c.data == "payment_done")
-    dp.register_callback_query_handler(upload_another, lambda c: c.data and c.data == "upload_another")
+    dp.register_callback_query_handler(
+        process_payment,
+        lambda c: c.data == "process_payment",
+        state=TranslationStates.waiting_for_payment_confirmation,
+    )
+    dp.register_callback_query_handler(
+        payment_done,
+        lambda c: c.data == "payment_done",
+        state=TranslationStates.waiting_for_payment_confirmation,
+    )
+    dp.register_callback_query_handler(
+        upload_another,
+        lambda c: c.data == "upload_another",
+        state=TranslationStates.waiting_for_payment_confirmation,
+    )

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -1,6 +1,7 @@
 from aiogram import types
 from aiogram.dispatcher import FSMContext
 from states import TranslationStates
+from handlers.language import build_language_keyboard
 import logging
 
 logger = logging.getLogger(__name__)
@@ -71,24 +72,8 @@ async def choose_model(callback: types.CallbackQuery, state: FSMContext):
         # Відправляємо вибір мови оригіналу
         await callback.message.answer("<b>Крок 2/5:</b> Оберіть мову оригіналу:", parse_mode="HTML")
         
-        # Кнопки мов - СТВОРЮЄМО ПРЯМО ТУТ
-        keyboard = types.InlineKeyboardMarkup(row_width=3)
-        keyboard.add(
-            types.InlineKeyboardButton("🇺🇦 UKR", callback_data="lang_UK"),
-            types.InlineKeyboardButton("🇬🇧 ENG", callback_data="lang_EN"),
-            types.InlineKeyboardButton("🇩🇪 GER", callback_data="lang_DE")
-        )
-        keyboard.add(
-            types.InlineKeyboardButton("🇫🇷 FRA", callback_data="lang_FR"),
-            types.InlineKeyboardButton("🇪🇸 SPA", callback_data="lang_ES"),
-            types.InlineKeyboardButton("🇵🇱 POL", callback_data="lang_PL")
-        )
-        keyboard.add(
-            types.InlineKeyboardButton("🇷🇺 RUS", callback_data="lang_RU"),
-            types.InlineKeyboardButton("🇨🇳 CHN", callback_data="lang_ZH"),
-            types.InlineKeyboardButton("🇯🇵 JPN", callback_data="lang_JA")
-        )
-        
+        # Динамічні кнопки мов
+        keyboard = build_language_keyboard()
         await callback.message.answer("Виберіть мову:", reply_markup=keyboard)
         
         logger.info(f"✅ МОДЕЛЬ {model} вибрана для користувача {callback.from_user.id}")
@@ -153,8 +138,12 @@ def register_handlers_start(dp):
     dp.register_message_handler(cmd_start, commands=["start"], state="*")
     logger.info("✅ Зареєстровано cmd_start")
     
-    # Вибір моделі - БЕЗ ФІЛЬТРІВ (КЛЮЧОВЕ ВИПРАВЛЕННЯ)
-    dp.register_callback_query_handler(choose_model)
+    # Вибір моделі
+    dp.register_callback_query_handler(
+        choose_model,
+        lambda c: c.data and c.data.startswith("model_"),
+        state=TranslationStates.choosing_model,
+    )
     logger.info("✅ Зареєстровано choose_model")
     
     # Продовження

--- a/utils/payment_utils.py
+++ b/utils/payment_utils.py
@@ -16,7 +16,9 @@ def calculate_price(chars: int, model: str) -> float:
     price = units * price_per_unit
     return round(max(price, min_price), 2)
 
-def create_payment_session(amount_eur: float, user_id: int, char_count: int, model: str) -> Optional[str]:
+def create_payment_session(
+    amount_eur: float, user_id: int, char_count: int, model: str
+) -> Optional[tuple]:
     """Create Stripe payment session"""
     try:
         model_name = config.MODELS[model]["name"]
@@ -44,8 +46,10 @@ def create_payment_session(amount_eur: float, user_id: int, char_count: int, mod
                 'model': model
             }
         )
-        logger.info(f"Created payment session for user {user_id}, amount: {amount_eur}€, model: {model}")
-        return session.url
+        logger.info(
+            f"Created payment session for user {user_id}, amount: {amount_eur}€, model: {model}"
+        )
+        return session.url, session.id
     except Exception as e:
         logger.error(f"Error creating payment session for user {user_id}: {str(e)}")
         return None

--- a/utils/translate_utils.py
+++ b/utils/translate_utils.py
@@ -2,7 +2,7 @@ import requests
 import time
 import config
 import logging
-from typing import Optional
+from typing import Optional, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -50,3 +50,49 @@ def translate_text_deepl(text: str, target_lang: str, source_lang: str = None) -
     except Exception as e:
         logger.error(f"Unexpected error during DeepL translation: {str(e)}")
         raise Exception(f"Помилка перекладу: {str(e)}")
+
+
+def fetch_deepl_languages() -> Dict[str, str]:
+    """Fetch available target languages from DeepL"""
+    try:
+        response = requests.get(
+            "https://api-free.deepl.com/v2/languages",
+            params={"type": "target"},
+            headers={"Authorization": f"DeepL-Auth-Key {config.DEEPL_API_KEY}"},
+            timeout=30,
+        )
+        if response.status_code == 200:
+            languages = {
+                lang["language"].upper(): lang.get("name", lang["language"])
+                for lang in response.json()
+            }
+            return languages
+        logger.error(
+            f"Failed to fetch DeepL languages: {response.status_code} {response.text}"
+        )
+    except Exception as e:
+        logger.error(f"Error fetching DeepL languages: {str(e)}")
+    return {}
+
+
+def fetch_otranslator_languages() -> Dict[str, str]:
+    """Fetch available languages from O*Translator"""
+    try:
+        response = requests.get(
+            f"{config.OTRANSLATOR_API_URL}/languages",
+            headers={"Authorization": f"Bearer {config.OTRANSLATOR_API_KEY}"},
+            timeout=30,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            languages = {
+                item["code"].upper(): item.get("name", item["code"])
+                for item in data.get("languages", [])
+            }
+            return languages
+        logger.error(
+            f"Failed to fetch OTranslator languages: {response.status_code} {response.text}"
+        )
+    except Exception as e:
+        logger.error(f"Error fetching OTranslator languages: {str(e)}")
+    return {}


### PR DESCRIPTION
## Summary
- fix callback handler registration to ensure correct filters and states
- integrate dynamic languages from DeepL and Otranslator APIs
- add real Stripe payment session with character-based pricing

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688564f83da48330b4deb326266d9141